### PR TITLE
revisions from the first referee report (related to "space-filling")

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The repository is organized as follows:
 
     * [runtime\_geometries/](data/runtime_geometries)
 
-        "Chemically-informed" and naive structures and settings in the form of `ase.traj` files, corresponding to the discussion surrounding Figure 3 in the paper. The files can be read using ASE package (using [`ase.io.read`](https://wiki.fysik.dtu.dk/ase/ase/io/io.html#ase.io.read)).
+        "Chemically-informed" and naive structures and settings in the form of `ase.traj` files, corresponding to the discussion surrounding FIG.~3 in the main text. The files can be read using ASE package (using [`ase.io.read`](https://wiki.fysik.dtu.dk/ase/ase/io/io.html#ase.io.read)).
 
 2. [scripts/](scripts)
 
@@ -28,12 +28,15 @@ The repository is organized as follows:
 
     * `sequential_learning.py`: Script for running multiple independent trials of sequential learning (SL) and recording a history of training examples, model predictions and prediction uncertainties.
     
-        If run as-is, the script performs 20 independent trials of 100 SL iterations to optimize the `binding_energy_of_adsorbed` property in the bimetallic catalysts dataset mentioned above, using three acquisition functions (results from each recorded separately): random, maximum likelihood of improvement (MLI) and maximum uncertainty (MU).
+        If run as-is, the script performs 20 independent trials of 100 SL iterations to optimize the `binding_energy_of_adsorbed` property in the bimetallic catalysts dataset mentioned above, using four acquisition functions (results from each recorded separately): random, maximum likelihood of improvement (MLI), maximum uncertainty (MU), and space-filling.
 
     * `plot_acceleration_from_sequential_learning.py`: Script to aggregate results from the `sequential_learning.py` script, calculate and plot statistics related to acceleration from SL over a baseline.
 
-        If run as-is, the script reproduces the 3-paneled Figure 5 in the paper.
+        If run as-is, the script reproduces the 3-paneled FIG.~5 in the main text.
 
+    * `plot_acceleration_from_sequential_learning__ALL_ACQ.py`: Similar to the previous script; plots and compares statistics from all acquisition functions considered (MLI, MU, random, space-filling) for all SL tasks.
+
+        If run as-is, the script reproduces the 3-paneled FIG.~S1 in the Supplementary Information.
 
 ## Running the scripts
 

--- a/scripts/plot_acceleration_from_sequential_learning.py
+++ b/scripts/plot_acceleration_from_sequential_learning.py
@@ -457,7 +457,7 @@ def accuracy_per_iteration_plot(
     ax.set_ylim([0.025, max(mean) * 1.05])
     ax.set_xticks(np.arange(init_train_size, ax.get_xlim()[-1] + 1, 20))
     ax.set_xlabel("Size of training data")
-    ax.set_ylabel("Model test accuracy (MAE in eV)")
+    ax.set_ylabel("Model test error (MAE in eV)")
     print("Done.\n")
 
 

--- a/scripts/plot_acceleration_from_sequential_learning__ALL_ACQ.py
+++ b/scripts/plot_acceleration_from_sequential_learning__ALL_ACQ.py
@@ -342,7 +342,8 @@ def distances_per_iteration_plot(
     Plot the average candidate distance to the target window as a function of SL
     iteration, and color an area around the average to indicate uncertainty (calculated
     as +/- std over independent SL trials). Compare the performance of maximum
-    likelihood of improvement (MLI) and random acquisition functions.
+    likelihood of improvement (MLI), maximum uncertainty (MU), space-filling, 
+    and random acquisition functions.
 
     Args:
         df (pd.DataFrame): The full dataset.

--- a/scripts/plot_acceleration_from_sequential_learning__ALL_ACQ.py
+++ b/scripts/plot_acceleration_from_sequential_learning__ALL_ACQ.py
@@ -7,7 +7,7 @@ averaging, and plotting functionalities implemented here contain several hard-co
 problem-specific parameters. Please do not expect these functions to work as-is without
 modifications for generating similar figures for a different problem.
 
-The `make_figure` function encapsulates the overall task of generating Figure 5, with
+The `make_figure` function encapsulates the overall task of generating Figure S1, with
 functionality related to plotting individual panels delegated to
 `["targets"/"distances"/"iterations"]_per_iteration_plot` functions.
 A typical workflow can be found in the module execution block at the bottom.

--- a/scripts/plot_acceleration_from_sequential_learning__ALL_ACQ.py
+++ b/scripts/plot_acceleration_from_sequential_learning__ALL_ACQ.py
@@ -255,7 +255,8 @@ def targets_per_iteration_plot(
     Plot the average number of candidates found in the target window as a function of SL
     iteration, and color an area around the average to indicate uncertainty (calculated
     as +/- std over independent SL trials). Compare the performance of maximum
-    likelihood of improvement (MLI) and random acquisition functions.
+    likelihood of improvement (MLI), maximum uncertainty (MU), space-filling, 
+    and random acquisition functions.
 
     Args:
         df (pd.DataFrame): The full dataset.

--- a/scripts/plot_acceleration_from_sequential_learning__ALL_ACQ.py
+++ b/scripts/plot_acceleration_from_sequential_learning__ALL_ACQ.py
@@ -483,7 +483,7 @@ def accuracy_per_iteration_plot(
     ax.set_ylim([0.025, max(mean) * 1.10])
     ax.set_xticks(np.arange(init_train_size, ax.get_xlim()[-1] + 1, 20))
     ax.set_xlabel("Size of training data")
-    ax.set_ylabel("Model test accuracy (MAE in eV)")
+    ax.set_ylabel("Model test error (MAE in eV)")
     print("Done.\n")
 
 

--- a/scripts/plot_acceleration_from_sequential_learning__ALL_ACQ.py
+++ b/scripts/plot_acceleration_from_sequential_learning__ALL_ACQ.py
@@ -408,8 +408,9 @@ def accuracy_per_iteration_plot(
     ax: Axes = None,
 ):
     """
-    Plot model accuracy as a function of SL iteration for the maximum uncertainty (MU)
-    acquisition function, and color an area around the average to indicate uncertainty
+    Plot model accuracy as a function of SL iteration for, maximum uncertainty (MU),
+    maximum likelihood of improvement (MLI), space-filling, and random
+    acquisition functions, and color an area around the average to indicate uncertainty
     (calculated as +/- std over independent SL trials).
 
     Args:

--- a/scripts/sequential_learning.py
+++ b/scripts/sequential_learning.py
@@ -148,9 +148,8 @@ def choose_next_candidate(
         X = scaler.fit_transform(X)
         # calculate all pairwise distances between examples (feature vectors)
         D = euclidean_distances(X, X)
-        # print(f"D.shape: {D.shape}")
-        # choose the candidate in the design space that is farthest away from the
-        # training set
+        # choose the unlabelled candidate in the design space whose 
+        # closest neighbor in the training set is the farthest away
         next_idx = np.argmax(np.min(D[np.ix_(~train_mask, train_mask)], axis=1))
         parent_idx = np.arange(D.shape[0])[~train_mask][next_idx]
         max_score = np.max(np.min(D[np.ix_(~train_mask, train_mask)], axis=1))


### PR DESCRIPTION
Addresses one of the referee comments about comparing model accuracy with MU vs a `space-filling` approach.

- The sequential learning workflow now implements a Euclidean distance-based aggregation of the most-distant candidate (to the current training set, in the feature vector space) in each SL iteration.
- Adds a separate plotting script that prepares a figure comparing all four acquisition functions (MLI, MU, random, and space-filling), to be added to the SI.
- The previous plotting script now adds random to the model accuracy plot (panel 3 in the figure). 